### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,5 +23,3 @@ Server::get(IAppManager::class)->loadApp('privacy');
 if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
-
-OC_Hook::clear();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,18 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
 
-// Fix for "Autoload path not allowed: .../tests/lib/testcase.php"
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
+Server::get(IAppManager::class)->loadApp('privacy');
 
-// Fix for "Autoload path not allowed: .../privacy/tests/testcase.php"
-\OC_App::loadApp('privacy');
-
-if (!class_exists('\PHPUnit\Framework\TestCase')) {
+if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
 


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.